### PR TITLE
Change data order to make it compatible with kpsr-ai

### DIFF
--- a/image_directory.m
+++ b/image_directory.m
@@ -190,7 +190,7 @@ global image_data
 f = image_list(block.Dwork(1).Data);
 img = imread(fullfile(data_folder + '/images/', f.name));
 block.OutputPort(1).CurrentDimensions = size(img);
-block.OutputPort(1).Data = img;
+block.OutputPort(1).Data = permute(img, [2, 1, 3]);
 
 image_name = extractBetween(f.name, 1, length(f.name) - 4);
 [~,index] = ismember(image_name, image_data{:,1});


### PR DESCRIPTION
MATLAB stores data in column major HWC order for images. This means that the outermost dimension is contiguous in memory. By permuting the row/col, the image is effectively stored as row-major CHW order.